### PR TITLE
fixed of associations with the comments table

### DIFF
--- a/models/post.js
+++ b/models/post.js
@@ -4,10 +4,7 @@ module.exports = (sequelize, DataTypes) => {
   class Post extends Model {
     static associate(models) {
       Post.belongsTo(models.User, { as: 'user' });
-      Post.hasMany(models.Comment, {
-        foreignKey: 'commentId',
-        as: 'comments',
-      });
+      
     }
   }
   Post.init(

--- a/models/user.js
+++ b/models/user.js
@@ -7,10 +7,7 @@ module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     static associate(models) {
       User.belongsTo(models.Role, { as: 'role' });
-      User.hasMany(models.Comment, {
-        foreignKey: 'commentId',
-        as: 'comments',
-      });
+      
     }
   }
   User.init(


### PR DESCRIPTION
Cuando se realiza la petición donde obtengo todos los comentarios, este llama a un commentId que no encuentra. este commentId era usado en estas 2 tablas.

Eliminando estas asociaciones, la tabla Comments, sigue teniendo  relación con User y Post

