### PR TITLE
fix de swagger config

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,8 +38,7 @@ const options = {
       }
     ],
   },
-  apis: ['./routes/*.js',
-        './controllers/*.js']
+  apis: ['swagger.yaml']
 };
 
 const specs = swaggerJsDoc(options);


### PR DESCRIPTION
-cambié la config para que puedan escribir en el archivo swagger.yaml
-para documentar simplemente usen la sintaxis correcta y eviten la parte de la config inicial; pasen directamente a los paths o schemas